### PR TITLE
Update playbook.yaml - fix "Modify $ARGS" name

### DIFF
--- a/playbook.yaml
+++ b/playbook.yaml
@@ -43,13 +43,13 @@
         owner: root
         group: prometheus
         mode: '0750'
-    - name: Modify $ARGS for systemd < 1.5.0
+    - name: Modify $ARGS for Node Exporter < 1.5.0
       lineinfile:
         path: "/etc/default/prometheus-node-exporter"
         regexp: '^ARGS="'
         line: 'ARGS="--web.config /etc/prometheus-node-exporter/web-config.yml"'
       when: "packages['prometheus-node-exporter'][0]['version'] is version('1.5.0', '<')"
-    - name: Modify $ARGS for systemd > 1.5.0
+    - name: Modify $ARGS for Node Exporter > 1.5.0
       lineinfile:
         path: "/etc/default/prometheus-node-exporter"
         regexp: '^ARGS="'


### PR DESCRIPTION
The playbook code checks the version of the Node Exporter package, but the name of the task mistakenly uses "systemd"